### PR TITLE
fix(route): add browser-like headers for foresightnews

### DIFF
--- a/lib/routes/foresightnews/util.tsx
+++ b/lib/routes/foresightnews/util.tsx
@@ -21,9 +21,21 @@ const params = {
 const rootUrl = 'https://foresightnews.pro';
 const apiRootUrl = 'https://api.foresightnews.pro';
 const imgRootUrl = 'https://img.foresightnews.pro';
+const frontendRootUrl = 'https://s.foresightnews.pro';
 
 const icon = new URL('foresight.ico', rootUrl).href;
 const image = new URL('vertical_logo.png', imgRootUrl).href;
+
+const apiHeaders = {
+    accept: 'application/json, text/plain, */*',
+    'accept-language': 'zh-CN,zh;q=0.9',
+    origin: frontendRootUrl,
+    referer: frontendRootUrl + '/',
+    'sec-fetch-dest': 'empty',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-site': 'same-site',
+    'x-requested-with': 'XMLHttpRequest',
+};
 
 const processItems = async (apiUrl, limit, ...parameters) => {
     let searchParams = {
@@ -41,6 +53,7 @@ const processItems = async (apiUrl, limit, ...parameters) => {
     };
 
     const { data: response } = await got(apiUrl, {
+        headers: apiHeaders,
         searchParams,
     });
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close DIYgod/RSSHub#21667

## Example for the Proposed Route(s) / 路由地址示例

```routes
/foresightnews
/foresightnews/article
/foresightnews/news
/foresightnews/column/1
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds browser-like request headers for Foresight News API calls so existing routes can fetch data without the 403 reported in the linked issue.

Validated with local route requests returning 200 and non-empty feed items.
